### PR TITLE
Updated blog post URL

### DIFF
--- a/_sources/index.txt
+++ b/_sources/index.txt
@@ -51,7 +51,7 @@ Announcements
 .. _watch the talk:
    http://www.archive.org/details/Wednesday-203-6-IpythonANewArchitectureForInteractiveAndParallel
 .. _visual tour of the new features:
-   http://stronginference.com/weblog/2011/7/15/innovations-in-ipython.html
+   http://fonnesbeck.calepin.co/innovations-in-ipython.html
 
 .. image:: _static/ipy_0.11.png
   

--- a/index.html
+++ b/index.html
@@ -193,7 +193,7 @@ for providing this.</li>
 <a class="reference external" href="download.html">Download</a> it now, or look at <a class="reference external" href="http://ipython.org/ipython-doc/rel-0.11/whatsnew/version0.11.html">what&#8217;s new</a>.  At
 the recent SciPy 2011 conference we gave a talk about this version, you can
 <a class="reference external" href="http://fperez.org/talks/1107_ipython_scipy.pdf">download the slides</a> or <a class="reference external" href="http://www.archive.org/details/Wednesday-203-6-IpythonANewArchitectureForInteractiveAndParallel">watch the talk</a>; afterwards Chris Fonnesbeck
-wrote an excellent post with a <a class="reference external" href="http://stronginference.com/weblog/2011/7/15/innovations-in-ipython.html">visual tour of the new features</a>.</li>
+wrote an excellent post with a <a class="reference external" href="http://fonnesbeck.calepin.co/innovations-in-ipython.html">visual tour of the new features</a>.</li>
 </ul>
 <img alt="_images/ipy_0.11.png" src="_images/ipy_0.11.png" />
 <ul class="simple">


### PR DESCRIPTION
Just a correction to the URL for my blog post on iPython 0.11, which I moved to a different host.
